### PR TITLE
fix: cpp_impl import error on humble

### DIFF
--- a/CARET_analyze_cpp_impl/CMakeLists.txt
+++ b/CARET_analyze_cpp_impl/CMakeLists.txt
@@ -36,7 +36,7 @@ pybind11_add_module(record_cpp_impl
 )
 
 set(LIBRARY_DESTIONATION
-	"lib/python3.${Python3_VERSION_MINOR}/site-packages"
+  "lib/python3.${Python3_VERSION_MINOR}/site-packages"
 )
 install(
 

--- a/CARET_analyze_cpp_impl/CMakeLists.txt
+++ b/CARET_analyze_cpp_impl/CMakeLists.txt
@@ -35,10 +35,14 @@ pybind11_add_module(record_cpp_impl
   "src/pybind.cpp"
 )
 
+set(LIBRARY_DESTIONATION
+	"lib/python3.${Python3_VERSION_MINOR}/site-packages"
+)
 install(
+
   TARGETS record_cpp_impl
   EXPORT export_record_cpp_impl
-  LIBRARY DESTINATION lib/python3.8/site-packages
+  LIBRARY DESTINATION ${LIBRARY_DESTIONATION}
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

The default python version changed from 3.8 to 3.10, which caused import errors.
This patch addresses the minor version change in python.