### PR TITLE
chore(sync-files): remove pre-commit-config.yaml from sync-files

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -8,7 +8,7 @@
     - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
-    #	- source: .pre-commit-config.yaml  # Removed because it conflicts with pre-commit-ci
+    # - source: .pre-commit-config.yaml  # Removed because it conflicts with pre-commit-ci
     - source: .pre-commit-config-optional.yaml
     - source: .prettierignore
     - source: .prettierrc.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -8,7 +8,6 @@
     - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
-    - source: .pre-commit-config.yaml
     - source: .pre-commit-config-optional.yaml
     - source: .prettierignore
     - source: .prettierrc.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -8,7 +8,7 @@
     - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
-#	- source: .pre-commit-config.yaml  # Removed because it conflicts with pre-commit-ci
+    #	- source: .pre-commit-config.yaml  # Removed because it conflicts with pre-commit-ci
     - source: .pre-commit-config-optional.yaml
     - source: .prettierignore
     - source: .prettierrc.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -8,6 +8,7 @@
     - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
+#	- source: .pre-commit-config.yaml  # Removed because it conflicts with pre-commit-ci
     - source: .pre-commit-config-optional.yaml
     - source: .prettierignore
     - source: .prettierrc.yaml


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR removes pre-commit-config.yaml from sync-files to fix confliction between sync-files and pre-commit-ci.

- https://github.com/tier4/CARET_analyze_cpp_impl/pull/43
- https://github.com/tier4/CARET_analyze_cpp_impl/pull/40

After applying this PR, sync-files can be applied.
