### PR TITLE
fix: prevent segmentation fault and report warning

### DIFF
--- a/CARET_analyze_cpp_impl/src/records_base.cpp
+++ b/CARET_analyze_cpp_impl/src/records_base.cpp
@@ -715,7 +715,7 @@ std::unique_ptr<RecordsBase> RecordsBase::merge_sequential_for_addr_track(
         [&stamp_sets, &source_key, &record, &column_timestamp](const Record & x) {
           auto timestamp = x.get(column_timestamp);
           std::shared_ptr<StampSet> stamp_set = stamp_sets[timestamp];
-          if(stamp_set == nullptr) {
+          if　(stamp_set == nullptr) {
             std::string e = "WARNING : ";
             e += "The trace data may be corrupted. ";
             e += "Some elements are missing.";

--- a/CARET_analyze_cpp_impl/src/records_base.cpp
+++ b/CARET_analyze_cpp_impl/src/records_base.cpp
@@ -716,7 +716,9 @@ std::unique_ptr<RecordsBase> RecordsBase::merge_sequential_for_addr_track(
         [&stamp_sets, &source_key, &record, &column_timestamp](const Record & x) {
           auto timestamp = x.get(column_timestamp);
           std::shared_ptr<StampSet> stamp_set = stamp_sets[timestamp];
-          bool has_same_source_addrs = stamp_set->count(record.get(source_key)) > 0;
+          bool has_same_source_addrs = false;
+          if(stamp_set != nullptr)
+            has_same_source_addrs = stamp_set->count(record.get(source_key)) > 0;
           return has_same_source_addrs;
         };
       std::vector<uint64_t> merged_addrs;

--- a/CARET_analyze_cpp_impl/src/records_base.cpp
+++ b/CARET_analyze_cpp_impl/src/records_base.cpp
@@ -677,7 +677,6 @@ std::unique_ptr<RecordsBase> RecordsBase::merge_sequential_for_addr_track(
       }
     };
 
-
   auto bar = Progress(concat_records.size(), progress_label);
   for (auto it = concat_records.rbegin(); it->has_next(); it->next()) {
     auto & record = it->get_record();
@@ -716,7 +715,14 @@ std::unique_ptr<RecordsBase> RecordsBase::merge_sequential_for_addr_track(
         [&stamp_sets, &source_key, &record, &column_timestamp](const Record & x) {
           auto timestamp = x.get(column_timestamp);
           std::shared_ptr<StampSet> stamp_set = stamp_sets[timestamp];
-          bool has_same_source_addrs = (stamp_set != nullptr) && (stamp_set->count(record.get(source_key)) > 0);
+          if(stamp_set == nullptr) {
+            std::string e = "WARNING : ";
+            e += "The trace data may be corrupted. ";
+            e += "Some elements are missing.";
+            std::cout << e << std::endl;
+            return false;
+          }
+          bool has_same_source_addrs = (stamp_set->count(record.get(source_key)) > 0);
           return has_same_source_addrs;
         };
       std::vector<uint64_t> merged_addrs;

--- a/CARET_analyze_cpp_impl/src/records_base.cpp
+++ b/CARET_analyze_cpp_impl/src/records_base.cpp
@@ -716,9 +716,7 @@ std::unique_ptr<RecordsBase> RecordsBase::merge_sequential_for_addr_track(
         [&stamp_sets, &source_key, &record, &column_timestamp](const Record & x) {
           auto timestamp = x.get(column_timestamp);
           std::shared_ptr<StampSet> stamp_set = stamp_sets[timestamp];
-          bool has_same_source_addrs = false;
-          if(stamp_set != nullptr)
-            has_same_source_addrs = stamp_set->count(record.get(source_key)) > 0;
+          bool has_same_source_addrs = (stamp_set != nullptr) && (stamp_set->count(record.get(source_key)) > 0);
           return has_same_source_addrs;
         };
       std::vector<uint64_t> merged_addrs;

--- a/CARET_analyze_cpp_impl/src/records_base.cpp
+++ b/CARET_analyze_cpp_impl/src/records_base.cpp
@@ -715,7 +715,7 @@ std::unique_ptr<RecordsBase> RecordsBase::merge_sequential_for_addr_track(
         [&stamp_sets, &source_key, &record, &column_timestamp](const Record & x) {
           auto timestamp = x.get(column_timestamp);
           std::shared_ptr<StampSet> stamp_set = stamp_sets[timestamp];
-          if　(stamp_set == nullptr) {
+          if (stamp_set == nullptr) {
             std::string e = "WARNING : ";
             e += "The trace data may be corrupted. ";
             e += "Some elements are missing.";


### PR DESCRIPTION
## Description
Segmentation fault occurs when incomplete trace data is read in.

<!-- Write a brief description of this PR. -->

## Related links
https://tier4.atlassian.net/browse/RT2-134

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
