### PR TITLE
fix: segmentation fault in merge_sequential_for_addr_track

### DIFF
--- a/CARET_analyze_cpp_impl/src/records_base.cpp
+++ b/CARET_analyze_cpp_impl/src/records_base.cpp
@@ -729,7 +729,7 @@ std::unique_ptr<RecordsBase> RecordsBase::merge_sequential_for_addr_track(
 
         processing_record.merge(record);
         merged_records->append(processing_record);
-        merged_addrs.emplace_back(processing_record.get(sink_from_key));
+        merged_addrs.emplace_back(processing_record_pair.first);
       }
       for (auto & merged_addr : merged_addrs) {
         if (processing_records.count(merged_addr) > 0) {


### PR DESCRIPTION
## Description
Fixed incorrect map key specification, which was causing segmentation faults.

<!-- Write a brief description of this PR. -->

## Related links
https://tier4.atlassian.net/browse/RT2-134

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
